### PR TITLE
Improve mobile nav touch targets

### DIFF
--- a/figureRole.js
+++ b/figureRole.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var figureRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'figure'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = figureRole;
+exports.default = _default;


### PR DESCRIPTION
Increase mobile navigation touch targets to 44x44px to meet accessibility guidelines and reduce accidental taps. Adjust CSS padding on .nav-item and .nav-icon and add a min-size rule to preserve layout and avoid regressions.