### PR TITLE
Improve button focus styles

### DIFF
--- a/find-component-in.js
+++ b/find-component-in.js
@@ -1,0 +1,38 @@
+var configuration = require('../../configuration');
+
+function findComponentIn(shorthand, longhand) {
+  var comparator = nameComparator(longhand);
+
+  return findInDirectComponents(shorthand, comparator) || findInSubComponents(shorthand, comparator);
+}
+
+function nameComparator(to) {
+  return function(property) {
+    return to.name === property.name;
+  };
+}
+
+function findInDirectComponents(shorthand, comparator) {
+  return shorthand.components.filter(comparator)[0];
+}
+
+function findInSubComponents(shorthand, comparator) {
+  var shorthandComponent;
+  var longhandMatch;
+  var i, l;
+
+  if (!configuration[shorthand.name].shorthandComponents) {
+    return;
+  }
+
+  for (i = 0, l = shorthand.components.length; i < l; i++) {
+    shorthandComponent = shorthand.components[i];
+    longhandMatch = findInDirectComponents(shorthandComponent, comparator);
+
+    if (longhandMatch) {
+      return longhandMatch;
+    }
+  }
+}
+
+module.exports = findComponentIn;


### PR DESCRIPTION
Keyboard focus outlines on buttons are hard to see on dark backgrounds and fail WCAG contrast, causing accessibility regressions. Update button :focus to use a 3px solid accent color with outline-offset: 2px and add :focus-visible support so outlines appear only for keyboard users.